### PR TITLE
Refactor AnalysisConfig to derive paths from site and observation_date

### DIFF
--- a/src/airglow/dagster_airglow/assets/analysis_asset.py
+++ b/src/airglow/dagster_airglow/assets/analysis_asset.py
@@ -22,11 +22,29 @@ class AnalysisConfig(dg.Config):
     """Model representing the output from the unzip_chunked_archive asset."""
 
     site: str = "uao"
-    year: str = "2025"
     observation_date: str = "20250429"
-    fpi_data_path: str = "fpi/minime05/uao/2025/20250429"
-    cloud_cover_path: str = "cloudsensor/uao/2025"
     fail_asset_on_all_errors: bool = False  # Set to True if you want the asset to fail when all processing fails
+
+    @property
+    def year(self) -> str:
+        """Extract year from observation_date (format: YYYYMMDD)."""
+        return self.observation_date[:4]
+
+    @property
+    def cloud_cover_path(self) -> str:
+        """Construct cloud cover path from site and year."""
+        return f"cloudsensor/{self.site}/{self.year}"
+
+    @property
+    def fpi_data_path(self) -> str:
+        """Construct FPI data path from site, year, and observation_date."""
+        # Parse observation_date to get datetime
+        nominal_dt = datetime.strptime(self.observation_date, "%Y%m%d")
+
+        # Get instrument name from fpiinfo
+        instr_name = fpiinfo.get_instr_at(self.site, nominal_dt)[0]
+
+        return f"fpi/{instr_name}/{self.site}/{self.year}/{self.observation_date}"
 
 
 class DagsterErrorHandler:

--- a/src/airglow/dagster_airglow/assets/upload_chunked_archive.py
+++ b/src/airglow/dagster_airglow/assets/upload_chunked_archive.py
@@ -108,10 +108,7 @@ def unzip_chunked_archive(
 
     analysis_config = AnalysisConfig(
         site=config.site,
-        year=year,
         observation_date=config.observation_date,
-        fpi_data_path=data_path,
-        cloud_cover_path=cloud_cover_path,
     )
 
     delete_raw_config = DeleteRawConfig(

--- a/tests/integration_tests/test_analysis_asset.py
+++ b/tests/integration_tests/test_analysis_asset.py
@@ -17,11 +17,8 @@ logger = logging.getLogger(__name__)
 def test_analysis(s3_resource):
     context = build_asset_context(resources={"s3": s3_resource, "mysql": None})
     config = AnalysisConfig(
-        observation_date="20250425",
-        year="2025",
         site="uao",
-        fpi_data_path="fpi/minime05/uao/2025/20250425",
-        cloud_cover_path="cloudsensor/uao",
+        observation_date="20250425",
     )
     reanalyze_data(
         context,


### PR DESCRIPTION
- Changed AnalysisConfig to only require site and observation_date as input parameters
- Added computed properties for year, fpi_data_path, and cloud_cover_path
- year is extracted from observation_date (YYYYMMDD format)
- cloud_cover_path is constructed as cloudsensor/{site}/{year}
- fpi_data_path is constructed as fpi/{instr_name}/{site}/{year}/{observation_date} where instr_name is obtained from fpiinfo.get_instr_at()
- Updated all instantiations of AnalysisConfig to only pass site and observation_date